### PR TITLE
Add option to not add brackets in name and to hide tabline when there's only a single buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ require('tabline').setup({})
 require('tabline').setup({
     show_index = true,        -- show tab index
     show_modify = true,       -- show buffer modification indicator
+    bracket_in_name = true,   -- show brackets in name
     modify_indicator = '[+]', -- modify indicator
     no_name = '[No name]',    -- no name buffer name
 })

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ require('tabline').setup({})
 
 ```lua
 require('tabline').setup({
-    show_index = true,        -- show tab index
-    show_modify = true,       -- show buffer modification indicator
-    bracket_character = true, -- show brackets in name
-    modify_indicator = '[+]', -- modify indicator
-    no_name = '[No name]',    -- no name buffer name
+    show_index = true,         -- show tab index
+    show_modify = true,        -- show buffer modification indicator
+    bracket_character = true,  -- show brackets in name
+    hide_single_buffer = false,-- hide tabline when there's only one buffer
+    modify_indicator = '[+]',  -- modify indicator
+    no_name = '[No name]',     -- no name buffer name
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require('tabline').setup({})
 require('tabline').setup({
     show_index = true,        -- show tab index
     show_modify = true,       -- show buffer modification indicator
-    bracket_in_name = true,   -- show brackets in name
+    bracket_character = true, -- show brackets in name
     modify_indicator = '[+]', -- modify indicator
     no_name = '[No name]',    -- no name buffer name
 })

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -8,6 +8,7 @@ M.options = {
     show_index = true,
     show_modify = true,
     bracket_character = true,
+    hide_single_buffer = false,
     modify_indicator = '[+]',
     no_name = '[No Name]',
 }
@@ -64,7 +65,13 @@ function M.setup(user_options)
         return tabline(M.options)
     end
 
-    vim.o.showtabline = 2
+    local showtabline = 2
+
+    if M.options.hide_single_buffer == true  then
+	showtabline = 1
+    end
+
+    vim.o.showtabline = showtabline
     vim.o.tabline = '%!v:lua.nvim_tabline()'
 
     vim.g.loaded_nvim_tabline = 1

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -5,9 +5,9 @@ local M = {}
 local fn = vim.fn
 
 M.options = {
-    show_index = false,
+    show_index = true,
     show_modify = true,
-	bracket_in_name = false,
+    bracket_in_name = true,
     modify_indicator = '[+]',
     no_name = '[No Name]',
 }

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -5,8 +5,9 @@ local M = {}
 local fn = vim.fn
 
 M.options = {
-    show_index = true,
+    show_index = false,
     show_modify = true,
+	bracket_in_name = false,
     modify_indicator = '[+]',
     no_name = '[No Name]',
 }
@@ -34,7 +35,11 @@ local function tabline(options)
         end
         -- buf name
         if bufname ~= '' then
-            s = s .. '[' .. fn.fnamemodify(bufname, ':t') .. '] '
+			if options.bracket_in_name == true then
+				s = s .. '[' .. fn.fnamemodify(bufname, ':t') .. '] '
+			else
+				s = s .. '' .. fn.fnamemodify(bufname, ':t') .. ' '
+			end
         else
             s = s .. options.no_name .. ' '
         end

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -7,7 +7,7 @@ local fn = vim.fn
 M.options = {
     show_index = true,
     show_modify = true,
-    bracket_in_name = true,
+    bracket_character = true,
     modify_indicator = '[+]',
     no_name = '[No Name]',
 }
@@ -35,11 +35,11 @@ local function tabline(options)
         end
         -- buf name
         if bufname ~= '' then
-			if options.bracket_in_name == true then
-				s = s .. '[' .. fn.fnamemodify(bufname, ':t') .. '] '
-			else
-				s = s .. '' .. fn.fnamemodify(bufname, ':t') .. ' '
-			end
+	    if options.bracket_character == true then
+		s = s .. '[' .. fn.fnamemodify(bufname, ':t') .. '] '
+	    else
+		s = s .. '' .. fn.fnamemodify(bufname, ':t') .. ' '
+	    end	
         else
             s = s .. options.no_name .. ' '
         end


### PR DESCRIPTION
This pr introduces two new options, one to enable the user to remove the brackets around the filename and the other to hide the tabline when there's only a single buffer
```lua
bracket_character = true
hide_single_buffer = false
```