### PR TITLE
Remove the mandatory space between the title and modify_indicator

### DIFF
--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -56,7 +56,7 @@ local function tabline(options)
         then
             s = s .. options.modify_indicator
         end
-	-- additional space at the end of each tab segment
+	    -- additional space at the end of each tab segment
         s = s .. ' '
     end
 

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -47,15 +47,17 @@ local function tabline(options)
         else
             s = s .. options.no_name
         end
-        s = s .. options.brackets[2] .. ' '
+        s = s .. options.brackets[2]
         -- modify indicator
         if
             bufmodified == 1
             and options.show_modify
             and options.modify_indicator ~= nil
         then
-            s = s .. options.modify_indicator .. ' '
+            s = s .. options.modify_indicator
         end
+	-- additional space at the end of each tab segment
+        s = s .. ' '
     end
 
     s = s .. '%#TabLineFill#'

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -56,7 +56,7 @@ local function tabline(options)
         then
             s = s .. options.modify_indicator
         end
-	    -- additional space at the end of each tab segment
+        -- additional space at the end of each tab segment
         s = s .. ' '
     end
 

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -10,7 +10,7 @@ M.options = {
     show_icon = false,
     brackets = { '[', ']' },
     no_name = 'No Name',
-    modify_indicator = '[+]',
+    modify_indicator = ' [+]',
 }
 
 local function tabline(options)


### PR DESCRIPTION
This PR is to remove what seemed to be a mandatory space between the title segment and modify_indicator. 

While such a space could be specified in `brackets`, I'd be more than happy to add a new option to remove such a space instead. 