### PR TITLE
Allow fnamemodify to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ require('tabline').setup({
     show_index = true,           -- show tab index
     show_modify = true,          -- show buffer modification indicator
     show_icon = false,           -- show file extension icon
-    fnamemodify = ':t',          -- file name modifier, or function to modify the filename to title
+    fnamemodify = ':t',          -- file name modifier string
+                                 -- can be a function to modify buffer name
     modify_indicator = '[+]',    -- modify indicator
     no_name = 'No name',         -- no name buffer name
     brackets = { '[', ']' },     -- file name brackets surrounding

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require('tabline').setup({
     show_index = true,           -- show tab index
     show_modify = true,          -- show buffer modification indicator
     show_icon = false,           -- show file extension icon
-    fnamemodify = ':t',          -- file name modifier
+    fnamemodify = ':t',          -- file name modifier, or function to modify the filename to title
     modify_indicator = '[+]',    -- modify indicator
     no_name = 'No name',         -- no name buffer name
     brackets = { '[', ']' },     -- file name brackets surrounding

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -46,7 +46,11 @@ local function tabline(options)
         s = s .. options.brackets[1]
         local pre_title_s_len = string.len(s)
         if bufname ~= '' then
-            s = s .. icon .. fn.fnamemodify(bufname, options.fnamemodify)
+            if type(options.fnamemodify) == 'function' then
+                s = s .. icon .. options.fnamemodify(bufname)
+            else
+                s = s .. icon .. fn.fnamemodify(bufname, options.fnamemodify)
+            end
         else
             s = s .. options.no_name
         end


### PR DESCRIPTION
Give the user more power / customization by allowing them to use either an `fnamemodify` option string like it currently does OR a function that inputs the buffer name and returns the title string for the tab.

I found this useful/powerful for a couple of scenarios I ran into:

- Could shorten names when too long
- Searched for duplicate file names w/ different path and format the name so you can tell which is which. 
 
For example, I have a repo I work on with similarly named files i.e. common/v1.py, external/v1.py, internal/v1.py, so I can make my function look for multiple files name v1.py and extend the path in that case.

Lots of possibilities.